### PR TITLE
Redesign log view to be a table instead [WIP]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
                 "framer-motion": "^8.5.4",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
+                "react-icons": "^4.7.1",
                 "react-scripts": "5.0.1",
                 "react-virtuoso": "^4.0.6",
                 "typescript": "^4.9.4",
@@ -16439,6 +16440,14 @@
                 }
             }
         },
+        "node_modules/react-icons": {
+            "version": "4.7.1",
+            "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.7.1.tgz",
+            "integrity": "sha512-yHd3oKGMgm7zxo3EA7H2n7vxSoiGmHk5t6Ou4bXsfcgWyhfDKMpyKfhHR6Bjnn63c+YXBLBPUql9H4wPJM6sXw==",
+            "peerDependencies": {
+                "react": "*"
+            }
+        },
         "node_modules/react-is": {
             "version": "17.0.2",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -31230,6 +31239,12 @@
                 "use-callback-ref": "^1.3.0",
                 "use-sidecar": "^1.1.2"
             }
+        },
+        "react-icons": {
+            "version": "4.7.1",
+            "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.7.1.tgz",
+            "integrity": "sha512-yHd3oKGMgm7zxo3EA7H2n7vxSoiGmHk5t6Ou4bXsfcgWyhfDKMpyKfhHR6Bjnn63c+YXBLBPUql9H4wPJM6sXw==",
+            "requires": {}
         },
         "react-is": {
             "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "framer-motion": "^8.5.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-icons": "^4.7.1",
         "react-scripts": "5.0.1",
         "react-virtuoso": "^4.0.6",
         "typescript": "^4.9.4",

--- a/src/App.css
+++ b/src/App.css
@@ -36,10 +36,3 @@
         transform: rotate(360deg);
     }
 }
-
-/* Log View Styles */
-/* TODO move to another file */
-
-td.result-td {
-    cursor: pointer;
-}

--- a/src/App.css
+++ b/src/App.css
@@ -36,3 +36,10 @@
         transform: rotate(360deg);
     }
 }
+
+/* Log View Styles */
+/* TODO move to another file */
+
+td.result-td {
+    cursor: pointer;
+}

--- a/src/component/LogView.tsx
+++ b/src/component/LogView.tsx
@@ -40,6 +40,14 @@ export const LogView: React.FC<LogViewProps> = ({
             newExpandedRows.set(index, expanded);
             return newExpandedRows;
         });
+        performAutoScroll(index);
+    };
+
+    // TODO auto-scroll to exact position instead of to specific index
+    const performAutoScroll = async (index: number) => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        if (!ref.current) return;
+        ref.current.scrollToIndex(index);
     };
 
     const HeaderRow = () => {
@@ -50,22 +58,30 @@ export const LogView: React.FC<LogViewProps> = ({
 
         return (
             <Tr>
-                {queryResult.map((column) => (
-                    <Th
-                        width={200}
-                        style={{
-                            background: 'blue',
-                            color: 'white',
-                        }}
-                    >
-                        {(!queryDefinition.filteredColumns ||
+                <Th
+                    width="1px"
+                    style={{
+                        background: 'blue',
+                        color: 'white',
+                    }}
+                />
+                {queryResult.map(
+                    (column) =>
+                        (!queryDefinition.filteredColumns ||
                             queryDefinition.filteredColumns.length === 0 ||
                             queryDefinition.filteredColumns.includes(
                                 column.Field
-                            )) &&
-                            column.Field}
-                    </Th>
-                ))}
+                            )) && (
+                            <Th
+                                style={{
+                                    background: 'blue',
+                                    color: 'white',
+                                }}
+                            >
+                                {column.Field}
+                            </Th>
+                        )
+                )}
             </Tr>
         );
     };
@@ -77,10 +93,18 @@ export const LogView: React.FC<LogViewProps> = ({
         }
         const queryResult = queryResults[index];
 
-        let ci = 0;
-
         return (
             <Fragment key={`Row_${index}`}>
+                <Td
+                    style={{
+                        cursor: 'pointer',
+                    }}
+                    onClick={() => {
+                        expandCollapseRow(index, !expanded);
+                    }}
+                >
+                    {expanded ? <RiArrowDownSFill /> : <RiArrowRightSFill />}
+                </Td>
                 {queryResult.map((column) => {
                     // TODO fix filtered columns not taking up full width of table
                     if (
@@ -90,43 +114,22 @@ export const LogView: React.FC<LogViewProps> = ({
                     ) {
                         return <></>;
                     }
-                    ci += 1;
                     return (
                         <Td
                             className="result-td"
                             flexDirection={'column'}
-                            width={500}
                             maxWidth={1000}
+                            style={{
+                                cursor: 'pointer',
+                            }}
                             // TODO if just selecting text, do not expand/collapse the row
                             onClick={() => {
                                 expandCollapseRow(index, !expanded);
-                                // TODO fix table scrolling back to the top
-                                setTimeout(() => {
-                                    if (!ref.current) {
-                                        return;
-                                    }
-                                    ref.current.scrollIntoView({
-                                        index: index + 10,
-                                        behavior: 'auto',
-                                        done: () => {},
-                                    });
-                                }, 0);
                             }}
                         >
-                            <Flex justifyContent={'space-between'}>
-                                {ci === 1 ? (
-                                    <Box>
-                                        {expanded ? (
-                                            <RiArrowDownSFill />
-                                        ) : (
-                                            <RiArrowRightSFill />
-                                        )}
-                                    </Box>
-                                ) : (
-                                    <></>
-                                )}
-                                <Box whiteSpace={'normal'}>{column.Value}</Box>
-                            </Flex>
+                            <Box whiteSpace={'normal'} wordBreak="break-all">
+                                {column.Value}
+                            </Box>
                         </Td>
                     );
                 })}
@@ -148,7 +151,7 @@ export const LogView: React.FC<LogViewProps> = ({
                         overflowX={'initial'}
                     />
                 )),
-                Table: (props) => <Table {...props} variant="striped" />,
+                Table: (props) => <Table {...props} layout="fixed" />,
                 TableHead: Thead,
                 TableRow: (props) => {
                     const index = props['data-index'];
@@ -161,7 +164,12 @@ export const LogView: React.FC<LogViewProps> = ({
                             <Tr {...props} />
                             {queryResult && expanded && (
                                 <Tr>
-                                    <Td colSpan={5}>
+                                    <Td
+                                        colSpan={
+                                            queryDefinition.filteredColumns
+                                                .length + 1
+                                        }
+                                    >
                                         <Box>
                                             {queryResult.map((column) => (
                                                 <>
@@ -183,26 +191,8 @@ export const LogView: React.FC<LogViewProps> = ({
                                                                 onColumnRemove(
                                                                     column.Field
                                                                 );
-                                                                // TODO fix table scrolling back to the top
-                                                                setTimeout(
-                                                                    () => {
-                                                                        if (
-                                                                            !ref.current
-                                                                        ) {
-                                                                            return;
-                                                                        }
-                                                                        ref.current.scrollIntoView(
-                                                                            {
-                                                                                index:
-                                                                                    index +
-                                                                                    10,
-                                                                                behavior:
-                                                                                    'auto',
-                                                                                done: () => {},
-                                                                            }
-                                                                        );
-                                                                    },
-                                                                    0
+                                                                performAutoScroll(
+                                                                    index
                                                                 );
                                                             }}
                                                         >
@@ -219,26 +209,8 @@ export const LogView: React.FC<LogViewProps> = ({
                                                                 onColumnAdd(
                                                                     column.Field
                                                                 );
-                                                                // TODO fix table scrolling back to the top
-                                                                setTimeout(
-                                                                    () => {
-                                                                        if (
-                                                                            !ref.current
-                                                                        ) {
-                                                                            return;
-                                                                        }
-                                                                        ref.current.scrollIntoView(
-                                                                            {
-                                                                                index:
-                                                                                    index +
-                                                                                    10,
-                                                                                behavior:
-                                                                                    'auto',
-                                                                                done: () => {},
-                                                                            }
-                                                                        );
-                                                                    },
-                                                                    0
+                                                                performAutoScroll(
+                                                                    index
                                                                 );
                                                             }}
                                                         >

--- a/src/component/LogView.tsx
+++ b/src/component/LogView.tsx
@@ -133,7 +133,6 @@ export const LogView: React.FC<LogViewProps> = ({
                         </Td>
                     );
                 })}
-                {/* TODO fix the table horizontal scroll not appearing unless you scroll the document, the heights of the dashboard need to be adjusted so that the whole thing will fit in the view without scrolling */}
             </Fragment>
         );
     };

--- a/src/component/LogView.tsx
+++ b/src/component/LogView.tsx
@@ -1,8 +1,20 @@
-import { Box, Flex } from '@chakra-ui/react';
+import {
+    Box,
+    Flex,
+    Link,
+    Table,
+    TableContainer,
+    Tbody,
+    Td,
+    Th,
+    Thead,
+    Tr,
+} from '@chakra-ui/react';
 import { QueryResults } from '../action/query';
 import { QueryDefinition } from '../context/QueryControlContext';
-import { useState } from 'react';
-import { Virtuoso } from 'react-virtuoso';
+import { useState, useRef, forwardRef, Fragment } from 'react';
+import { TableVirtuoso, TableVirtuosoHandle } from 'react-virtuoso';
+import { RiArrowRightSFill, RiArrowDownSFill } from 'react-icons/ri';
 
 type LogViewProps = {
     queryDefinition: QueryDefinition;
@@ -20,6 +32,7 @@ export const LogView: React.FC<LogViewProps> = ({
     const [expandedRows, setExpandedRows] = useState<Map<number, boolean>>(
         new Map()
     );
+    const ref = useRef<TableVirtuosoHandle>(null);
 
     const expandCollapseRow = (index: number, expanded: boolean) => {
         setExpandedRows((expandedRows) => {
@@ -29,90 +42,231 @@ export const LogView: React.FC<LogViewProps> = ({
         });
     };
 
+    const HeaderRow = () => {
+        if (!queryResults || !queryResults.length) {
+            return <></>;
+        }
+        const queryResult = queryResults[0];
+
+        return (
+            <Tr>
+                {queryResult.map((column) => (
+                    <Th
+                        width={200}
+                        style={{
+                            background: 'blue',
+                            color: 'white',
+                        }}
+                    >
+                        {(!queryDefinition.filteredColumns ||
+                            queryDefinition.filteredColumns.length === 0 ||
+                            queryDefinition.filteredColumns.includes(
+                                column.Field
+                            )) &&
+                            column.Field}
+                    </Th>
+                ))}
+            </Tr>
+        );
+    };
+
     const Row = (index: number) => {
         const expanded = expandedRows.get(index);
-        if (!queryResults) {
+        if (!queryResults || !queryResults.length) {
             return <></>;
         }
         const queryResult = queryResults[index];
 
+        let ci = 0;
+
         return (
-            <Flex border="1px solid black" borderLeft="none" borderRight="none">
-                <Box width="200px" flexShrink={0}>
-                    {queryResult[0].Value}
-                </Box>
-                <Box width="50px" flexShrink={0}></Box>
-                <Flex flexDirection={'column'} flex={1} width={500}>
-                    <Box>
-                        {queryResult.map(
-                            (column) =>
-                                (!queryDefinition.filteredColumns ||
-                                    queryDefinition.filteredColumns.length ===
-                                        0 ||
-                                    queryDefinition.filteredColumns.includes(
-                                        column.Field
-                                    )) && (
-                                    <>
-                                        <span>
-                                            {column.Field}={column.Value}
-                                        </span>
-                                        <br />
-                                    </>
-                                )
-                        )}
-                    </Box>
-                    <a
-                        onClick={() => expandCollapseRow(index, !expanded)}
-                        href="#"
-                    >
-                        {expanded ? 'collapse' : 'expand'}
-                    </a>
-                    {expanded && (
-                        <Box>
-                            {queryResult.map((column) => (
-                                <>
-                                    <span>
-                                        {column.Field}={column.Value}
-                                    </span>
-                                    {queryDefinition.filteredColumns &&
-                                    queryDefinition.filteredColumns.includes(
-                                        column.Field
-                                    ) ? (
-                                        <a
-                                            style={{
-                                                marginLeft: '8px',
-                                            }}
-                                            href="#"
-                                            onClick={() =>
-                                                onColumnRemove(column.Field)
-                                            }
-                                        >
-                                            remove
-                                        </a>
-                                    ) : (
-                                        <a
-                                            style={{
-                                                marginLeft: '8px',
-                                            }}
-                                            href="#"
-                                            onClick={() =>
-                                                onColumnAdd(column.Field)
-                                            }
-                                        >
-                                            add
-                                        </a>
-                                    )}
-                                    <br />
-                                </>
-                            ))}
-                        </Box>
-                    )}
-                </Flex>
-            </Flex>
+            <Fragment key={`Row_${index}`}>
+                {queryResult.map((column) => {
+                    // TODO fix filtered columns not taking up full width of table
+                    if (
+                        queryDefinition.filteredColumns &&
+                        queryDefinition.filteredColumns.length > 0 &&
+                        !queryDefinition.filteredColumns.includes(column.Field)
+                    ) {
+                        return <></>;
+                    }
+                    ci += 1;
+                    return (
+                        <Td
+                            className="result-td"
+                            flexDirection={'column'}
+                            width={500}
+                            maxWidth={1000}
+                            // TODO if just selecting text, do not expand/collapse the row
+                            onClick={() => {
+                                expandCollapseRow(index, !expanded);
+                                // TODO fix table scrolling back to the top
+                                setTimeout(() => {
+                                    if (!ref.current) {
+                                        return;
+                                    }
+                                    ref.current.scrollIntoView({
+                                        index: index + 10,
+                                        behavior: 'auto',
+                                        done: () => {},
+                                    });
+                                }, 0);
+                            }}
+                        >
+                            <Flex justifyContent={'space-between'}>
+                                {ci === 1 ? (
+                                    <Box>
+                                        {expanded ? (
+                                            <RiArrowDownSFill />
+                                        ) : (
+                                            <RiArrowRightSFill />
+                                        )}
+                                    </Box>
+                                ) : (
+                                    <></>
+                                )}
+                                <Box whiteSpace={'normal'}>{column.Value}</Box>
+                            </Flex>
+                        </Td>
+                    );
+                })}
+                {/* TODO fix the table horizontal scroll not appearing unless you scroll the document, the heights of the dashboard need to be adjusted so that the whole thing will fit in the view without scrolling */}
+            </Fragment>
         );
     };
 
     return (
-        <Virtuoso totalCount={queryResults?.length || 0} itemContent={Row} />
+        <TableVirtuoso
+            ref={ref}
+            data={queryResults}
+            components={{
+                Scroller: forwardRef((props, ref) => (
+                    <TableContainer
+                        {...props}
+                        ref={ref}
+                        overflowY={'initial'}
+                        overflowX={'initial'}
+                    />
+                )),
+                Table: (props) => <Table {...props} variant="striped" />,
+                TableHead: Thead,
+                TableRow: (props) => {
+                    const index = props['data-index'];
+                    const expanded = expandedRows.get(index);
+                    const queryResult = queryResults
+                        ? queryResults[index]
+                        : undefined;
+                    return (
+                        <>
+                            <Tr {...props} />
+                            {queryResult && expanded && (
+                                <Tr>
+                                    <Td colSpan={5}>
+                                        <Box>
+                                            {queryResult.map((column) => (
+                                                <>
+                                                    <span>
+                                                        {column.Field}=
+                                                        {column.Value}
+                                                    </span>
+                                                    {queryDefinition.filteredColumns &&
+                                                    queryDefinition.filteredColumns.includes(
+                                                        column.Field
+                                                    ) ? (
+                                                        <Link
+                                                            style={{
+                                                                marginLeft:
+                                                                    '8px',
+                                                            }}
+                                                            href="#"
+                                                            onClick={() => {
+                                                                onColumnRemove(
+                                                                    column.Field
+                                                                );
+                                                                // TODO fix table scrolling back to the top
+                                                                setTimeout(
+                                                                    () => {
+                                                                        if (
+                                                                            !ref.current
+                                                                        ) {
+                                                                            return;
+                                                                        }
+                                                                        ref.current.scrollIntoView(
+                                                                            {
+                                                                                index:
+                                                                                    index +
+                                                                                    10,
+                                                                                behavior:
+                                                                                    'auto',
+                                                                                done: () => {},
+                                                                            }
+                                                                        );
+                                                                    },
+                                                                    0
+                                                                );
+                                                            }}
+                                                        >
+                                                            remove
+                                                        </Link>
+                                                    ) : (
+                                                        <Link
+                                                            style={{
+                                                                marginLeft:
+                                                                    '8px',
+                                                            }}
+                                                            href="#"
+                                                            onClick={() => {
+                                                                onColumnAdd(
+                                                                    column.Field
+                                                                );
+                                                                // TODO fix table scrolling back to the top
+                                                                setTimeout(
+                                                                    () => {
+                                                                        if (
+                                                                            !ref.current
+                                                                        ) {
+                                                                            return;
+                                                                        }
+                                                                        ref.current.scrollIntoView(
+                                                                            {
+                                                                                index:
+                                                                                    index +
+                                                                                    10,
+                                                                                behavior:
+                                                                                    'auto',
+                                                                                done: () => {},
+                                                                            }
+                                                                        );
+                                                                    },
+                                                                    0
+                                                                );
+                                                            }}
+                                                        >
+                                                            add
+                                                        </Link>
+                                                    )}
+                                                    <br />
+                                                </>
+                                            ))}
+                                        </Box>
+                                    </Td>
+                                </Tr>
+                            )}
+                        </>
+                    );
+                },
+                TableBody: forwardRef((props, ref) => (
+                    <Tbody
+                        {...props}
+                        ref={ref}
+                        style={{
+                            overflow: 'auto',
+                        }}
+                    />
+                )),
+            }}
+            fixedHeaderContent={HeaderRow}
+            itemContent={Row}
+        />
     );
 };

--- a/src/page/QueryPage.tsx
+++ b/src/page/QueryPage.tsx
@@ -173,6 +173,7 @@ export const QueryPage: React.FC<{}> = () => {
 
     const tabBarHeight = 58;
     const queryBoxHeight = 220;
+    const queryLabelHeight = 6;
 
     const handleColumnAdd = (column: string) => {
         const newQueryDef = JSON.parse(JSON.stringify(currentQueryDef));
@@ -319,11 +320,12 @@ export const QueryPage: React.FC<{}> = () => {
                                     style={{
                                         height: '100%',
                                         overflowX: 'hidden',
+                                        overflowY: "hidden",
                                     }}
                                     key={`QueryTabPanel=${index}`}
                                 >
                                     <Box height={queryBoxHeight}>
-                                        <Box data-cy="query-title">
+                                        <Box data-cy="query-title" height={queryLabelHeight}>
                                             {queryDefinition.queryId ||
                                                 'New Query'}
                                         </Box>
@@ -450,7 +452,7 @@ export const QueryPage: React.FC<{}> = () => {
                                     </Box>
                                     <Box
                                         style={{
-                                            height: `calc(100% - ${queryBoxHeight}px)`,
+                                            height: `calc(100% - ${queryBoxHeight + queryLabelHeight + tabBarHeight}px)`,
                                             margin: '2px',
                                         }}
                                     >


### PR DESCRIPTION
## To Do
- [x] Move Log View styles to another file
- [x] Fix filtered columns not taking up full width of table
- [ ] If just selecting text, do not expand/collapse the row
- [ ] Fix table scrolling back to the top when expanding/collapsing or adding/removing filtered column (stopgap measure added for now, but doesn't look great)
- [x] Spacing for arrow icon and first table cell sometimes splits them too far apart when there's not many columns
- [x] Fix table cell sizes fluctuating depending on size of content
- [x] Fix the table horizontal scroll not appearing unless you scroll the document (the heights of the dashboard need to be adjusted so that the whole thing will fit in the view without scrolling)
- [ ] Update log view tests
- [ ] Update screenshot test